### PR TITLE
fixed bug found by static analyzer

### DIFF
--- a/sys/netpfil/ipfw/ip_fw_sockopt.c
+++ b/sys/netpfil/ipfw/ip_fw_sockopt.c
@@ -2345,7 +2345,7 @@ compare_sh(const void *_a, const void *_b)
 
 	if ((uintptr_t)a->handler < (uintptr_t)b->handler)
 		return (-1);
-	else if ((uintptr_t)b->handler > (uintptr_t)b->handler)
+	else if ((uintptr_t)a->handler > (uintptr_t)b->handler)
 		return (1);
 
 	return (0);


### PR DESCRIPTION
Fixed bug that was found by static code analyzer

Comparison of identical expressions always evaluates to false at ip_fw_sockopt.c#L2348
