### PR TITLE
ipfw: the correct reset getopt in main

### DIFF
--- a/ipfw/main.c
+++ b/ipfw/main.c
@@ -261,7 +261,9 @@ ipfw_main(int oldac, char **oldav)
 	/* Save arguments for final freeing of memory. */
 	save_av = av;
 
-	optind = optreset = 1;	/* restart getopt() */
+	/* restart getopt() */
+	optreset = 1;
+	optind = 0;
 	while ((ch = getopt(ac, av, "abcdefhinNp:qs:STtv")) != -1)
 		switch (ch) {
 		case 'a':


### PR DESCRIPTION
**Bug found by fuzzing with AFL++**

```
==208==ERROR: AddressSanitizer: heap-use-after-free on address 0x614000000180 at pc 0x000000461767 bp 0x7fff56039310 sp 0x7fff56038ac0
READ of size 1 at 0x614000000180 thread T0
    #0 0x461766 in StrtolFixAndCheck(void*, char const*, char**, char*, int) (/usr/bin/ipfw+0x461766)
    #1 0x461b39 in strtol (/usr/bin/ipfw+0x461b39)
    #2 0x5a2844 in atoi /usr/include/stdlib.h:363:16
    #3 0x5a2844 in ipfw_main /root/rpmbuild/BUILD/netmap-ipfw-94a0f7e68c485bcc928894c9369e80d746cca41d/ipfw/main.c:319:17
    #4 0x59e8e6 in ipfw_readfile /root/rpmbuild/BUILD/netmap-ipfw-94a0f7e68c485bcc928894c9369e80d746cca41d/ipfw/main.c:574:3
    #5 0x59e8e6 in main /root/rpmbuild/BUILD/netmap-ipfw-94a0f7e68c485bcc928894c9369e80d746cca41d/ipfw/main.c:617:4
    #6 0x7f7d907971e1 in __libc_start_main (/lib64/libc.so.6+0x281e1)
    #7 0x41e70d in _start (/usr/bin/ipfw+0x41e70d)
```

The function "ipfw_main()" parses the list of command line arguments using "getopt()". Moreover, ipfw_main() can be called several times with a different list of command line arguments.

`optind = 1`  - the internal state of getopt() will NOT reset. See man 3 getopt:

> NOTES
> A program that scans multiple argument vectors, or rescans the same vector more than once, and wants to make use of > GNU extensions such as '+' and '-' at the start of optstring, or changes the value
> of POSIXLY_CORRECT between scans, must reinitialize getopt() by resetting optind to 0, rather than the traditional value > of 1. (Resetting to 0 forces the invocation of an internal initialization
> routine that rechecks POSIXLY_CORRECT and checks for GNU extensions in optstring.)

Further in lines 318-320:

```
case 's': /* sort */
	co.do_sort = atoi(optarg);
	break;
```
`optarg` indicates the memory from the previous run of `ipfw_main()`, which has already been freed, the sanitizer detects access to the already freed memory, and the program crashes with the error `Use of deallocated memory`.

How to fix it: you need to replace `optind = 1` with `optind = 0`.